### PR TITLE
creating config and fixing non-eisting elements in any-to-epip, when …

### DIFF
--- a/gtfs-netex-test/configuration.py
+++ b/gtfs-netex-test/configuration.py
@@ -1,0 +1,10 @@
+BASEDIR="./"   #/tmp/avv/
+DUCKDB='gtfs2.duckdb'
+NETEXOUTPUTDIR="netex-output"
+ANY2EPIPINPUT= "./netex-output/" #"/tmp/NeTEx_WSF_WSF_20240415_20240415.xml.gz"
+EPIAPFILENAME='./netex-output/FTG_Line_X31.xml' #/tmp/NeTEx_DOVA_epiap_20240423013251.xml.gz'
+# if there exists a local_configuration it is used.
+try:
+    from local_configuration import *
+except:
+    pass

--- a/gtfs-netex-test/import.py
+++ b/gtfs-netex-test/import.py
@@ -147,6 +147,7 @@ def handle_file(filename: str, column_mapping: dict):
     con.close()
 
 base_path = BASEDIR
+print(base_path)
 handle_file(base_path + 'gtfs/feed_info.txt', feed_info_txt)
 handle_file(base_path + 'gtfs/agency.txt', agency_txt)
 handle_file(base_path + 'gtfs/calendar_dates.txt', calendar_dates_txt)

--- a/gtfs-netex-test/import.py
+++ b/gtfs-netex-test/import.py
@@ -1,5 +1,7 @@
 import duckdb
 import csv
+from configuration import BASEDIR, DUCKDB
+
 
 agency_txt = {'agency_id': 'VARCHAR', 'agency_name': 'VARCHAR', 'agency_url': 'VARCHAR', 'agency_timezone': 'VARCHAR', 'agency_lang': 'VARCHAR', 'agency_phone': 'VARCHAR', 'agency_fare_url': 'VARCHAR', 'agency_email': 'VARCHAR'}
 stops_txt = {'stop_id': 'VARCHAR', 'stop_code': 'VARCHAR', 'stop_name': 'VARCHAR', 'tts_stop_name': 'VARCHAR', 'stop_desc': 'VARCHAR', 'stop_lat': 'FLOAT', 'stop_lon': 'FLOAT', 'zone_id': 'VARCHAR', 'stop_url': 'VARCHAR', 'location_type': 'INTEGER', 'parent_station': 'VARCHAR', 'stop_timezone': 'VARCHAR', 'wheelchair_boarding': 'INTEGER', 'level_id': 'VARCHAR', 'platform_code': 'VARCHAR'}
@@ -93,7 +95,7 @@ from chardet.universaldetector import UniversalDetector
 
 def handle_file(filename: str, column_mapping: dict):
     table = filename.split('/')[-1].replace('.txt', '')
-    con = duckdb.connect(database='gtfs2.duckdb')
+    con = duckdb.connect(database=DUCKDB)
     with duckdb.cursor(con) as cur:
         cur.execute(f"""DROP TABLE IF EXISTS {table};""")
 
@@ -144,7 +146,7 @@ def handle_file(filename: str, column_mapping: dict):
 
     con.close()
 
-base_path = '/tmp/avv/'
+base_path = BASEDIR
 handle_file(base_path + 'gtfs/feed_info.txt', feed_info_txt)
 handle_file(base_path + 'gtfs/agency.txt', agency_txt)
 handle_file(base_path + 'gtfs/calendar_dates.txt', calendar_dates_txt)


### PR DESCRIPTION
…coming from GTFS

* started with a configuration file (as we don't have the same configuration)
* Some elements don't exist when doing import.py GtfsNeTex.py then any-to-EPIP. They are now optional. Perhaps this is not what you want.

Tested it with flixbus:
* https://transport.data.gouv.fr/resources/11681?id=11681&locale=en
and blablacarbus
* https://transport.data.gouv.fr/datasets/blablacar-bus-horaires-theoriques-et-temps-reel-du-reseau-europeen

